### PR TITLE
Bump dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -135,7 +135,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-appcheck-safetynet:16.0.0-beta02'
 
     //Google Sign In
-    implementation 'com.google.android.gms:play-services-auth:19.0.0'
+    implementation 'com.google.android.gms:play-services-auth:20.4.1'
 
     //Picasso
     implementation 'com.squareup.picasso:picasso:2.71828'


### PR DESCRIPTION
…(#13)

Bumps com.google.android.gms:play-services-auth from 19.0.0 to 20.4.1.

---
updated-dependencies:
- dependency-name: com.google.android.gms:play-services-auth dependency-type: direct:production update-type: version-update:semver-major ...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>